### PR TITLE
Refactor setup scripts for better organization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,8 +62,18 @@ JWT_ALGORITHM=HS256
 JWT_EXPIRATION_HOURS=24
 
 # === Path Mapping Service ===
+# Container path (where files appear inside Docker containers)
 OBSIDIAN_VAULT_PATH=/app/data/vault
 GDRIVE_SYNC_PATH=/app/data/gdrive-sync
+
+# === Local Directory Path (Host System) ===
+# Set this to your actual Obsidian vault path on your local file system
+# Examples:
+#   Windows: C:/Users/YourName/Documents/ObsidianVault
+#   Linux: /home/yourname/Documents/ObsidianVault
+#   macOS: /Users/yourname/Documents/ObsidianVault
+# Leave empty to use default data directory (./data/vault)
+LOCAL_OBSIDIAN_PATH=
 
 # === Feature Flags ===
 ENABLE_PROACTIVE_SUGGESTIONS=true

--- a/README.md
+++ b/README.md
@@ -32,25 +32,58 @@ A unified, privacy-first AI platform combining advanced conversational intellige
 git clone https://github.com/lordmuffin/Maestro.git
 cd Maestro
 cp .env.example .env
-# Edit .env with your settings (set passwords, API keys)
+# Edit .env with your settings (set passwords, API keys, directory paths)
 
-# 2. Run first-time setup
+# 2. Configure your Obsidian vault path (recommended)
+# In .env, set LOCAL_OBSIDIAN_PATH to your existing vault location
+# Examples:
+#   Windows: LOCAL_OBSIDIAN_PATH=C:/Users/YourName/Documents/ObsidianVault
+#   Linux:   LOCAL_OBSIDIAN_PATH=/home/yourname/Documents/ObsidianVault
+#   macOS:   LOCAL_OBSIDIAN_PATH=/Users/yourname/Documents/ObsidianVault
+
+# 3. Run first-time setup
 chmod +x scripts/setup/first_run.sh
 ./scripts/setup/first_run.sh
 
-# 3. (Optional) Initialize Ollama for local LLM
+# 4. (Optional) Initialize Ollama for local LLM
 chmod +x scripts/setup/init_ollama.sh
 ./scripts/setup/init_ollama.sh
 
-# 4. Access the system
+# 5. Access the system
 # - Open WebUI: http://localhost:3000
 # - API Docs: http://localhost:8000/docs
 # - Health Check: http://localhost:8000/health
 ```
 
-### Google Drive Integration (Optional)
+### Obsidian Vault Configuration
 
-To enable Google Drive sync and cloud-based RAG with Gemini, configure the following environment variables in your `.env` file:
+Maestro can directly access your existing Obsidian vault on your local file system. This is the **recommended approach** for most users.
+
+#### Configure Local Vault Path (Recommended)
+
+Edit your `.env` file and set the `LOCAL_OBSIDIAN_PATH` variable to point to your vault directory:
+
+```bash
+# Local Obsidian Vault Path (Host System)
+LOCAL_OBSIDIAN_PATH=/path/to/your/obsidian/vault
+
+# Examples for different operating systems:
+# Windows:
+#   LOCAL_OBSIDIAN_PATH=C:/Users/YourName/Documents/ObsidianVault
+# Linux:
+#   LOCAL_OBSIDIAN_PATH=/home/yourname/Documents/ObsidianVault
+# macOS:
+#   LOCAL_OBSIDIAN_PATH=/Users/yourname/Documents/ObsidianVault
+```
+
+**Benefits:**
+- Direct access to your existing vault (no copying required)
+- Changes are immediately visible to Maestro
+- Works with any cloud sync solution you may use (Google Drive, Dropbox, OneDrive, Syncthing, etc.)
+
+### Google Drive API Integration (Optional)
+
+For advanced use cases, you can also enable Google Drive API integration for cloud-based RAG with Gemini. Configure the following environment variables in your `.env` file:
 
 #### Required Environment Variables
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -45,9 +45,12 @@ class Settings(BaseSettings):
     jwt_algorithm: str = "HS256"
     jwt_expiration_hours: int = 24
     
-    # Paths
+    # Paths (container paths)
     obsidian_vault_path: str = "/app/data/vault"
     gdrive_sync_path: str = "/app/data/gdrive-sync"
+
+    # Local host path (for setup scripts and volume mounting)
+    local_obsidian_path: Optional[str] = None
     
     # Feature Flags
     enable_proactive_suggestions: bool = True

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -53,11 +53,15 @@ services:
       - OLLAMA_HOST=${OLLAMA_HOST}
       - OLLAMA_MODEL=${OLLAMA_MODEL}
       - OBSIDIAN_VAULT_PATH=${OBSIDIAN_VAULT_PATH}
+      - GDRIVE_SYNC_PATH=${GDRIVE_SYNC_PATH}
+      - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}
+      - GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}
+      - GOOGLE_DRIVE_FOLDER_ID=${GOOGLE_DRIVE_FOLDER_ID}
       - LOG_LEVEL=${LOG_LEVEL}
     volumes:
       - ../backend:/app
-      - vault_data:/app/data/vault:ro
-      - credentials:/app/credentials:ro
+      - ${LOCAL_OBSIDIAN_PATH:-../data/vault}:/app/data/vault:ro
+      - ${GOOGLE_APPLICATION_CREDENTIALS:-../credentials}:/app/credentials:ro
     ports:
       - "8000:8000"
     depends_on:
@@ -99,5 +103,3 @@ volumes:
   postgres_data:
   ollama_data:
   openwebui_data:
-  vault_data:
-  credentials:

--- a/scripts/setup/first_run.sh
+++ b/scripts/setup/first_run.sh
@@ -15,7 +15,10 @@ if [ ! -f .env ]; then
     echo "  - JWT_SECRET"
     echo "  - WEBUI_SECRET_KEY"
     echo ""
-    echo "For Google Drive integration (optional), also configure:"
+    echo "To use your existing Obsidian vault:"
+    echo "  - LOCAL_OBSIDIAN_PATH (path to your Obsidian vault directory)"
+    echo ""
+    echo "For Google Drive API integration (optional), also configure:"
     echo "  - GOOGLE_CLOUD_PROJECT"
     echo "  - GOOGLE_APPLICATION_CREDENTIALS"
     echo "  - GOOGLE_DRIVE_FOLDER_ID"
@@ -26,16 +29,34 @@ fi
 # Load environment variables
 source .env
 
-# Create necessary directories
-echo "Creating data directories..."
-mkdir -p data/vault
+# Create necessary directories based on configuration
+echo "Setting up directories..."
+
+# Handle Obsidian vault path
+if [ -n "$LOCAL_OBSIDIAN_PATH" ]; then
+    echo "✓ Using local Obsidian vault at: $LOCAL_OBSIDIAN_PATH"
+    if [ ! -d "$LOCAL_OBSIDIAN_PATH" ]; then
+        echo "⚠️  Warning: LOCAL_OBSIDIAN_PATH does not exist: $LOCAL_OBSIDIAN_PATH"
+        echo "   Please create this directory or update LOCAL_OBSIDIAN_PATH in .env"
+    fi
+else
+    echo "Creating default data directories..."
+    mkdir -p data/vault
+    echo "✓ Default vault directory created at ./data/vault"
+fi
+
+# Create storage directory
 mkdir -p data/storage
 
-# Create Google Drive sync directory if Google Drive is configured
+# Create gdrive-sync directory if Google Drive API is configured
 if [ -n "$GOOGLE_DRIVE_FOLDER_ID" ] && [ "$GOOGLE_DRIVE_FOLDER_ID" != "your-drive-folder-id" ]; then
-    echo "Google Drive integration detected..."
+    echo "Google Drive API integration detected..."
     mkdir -p data/gdrive-sync
+    echo "✓ Google Drive sync directory created at ./data/gdrive-sync"
+fi
 
+# Validate Google Drive API credentials if configured
+if [ -n "$GOOGLE_DRIVE_FOLDER_ID" ] && [ "$GOOGLE_DRIVE_FOLDER_ID" != "your-drive-folder-id" ]; then
     # Check for Google credentials file
     if [ -n "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
         CREDS_FILE="${GOOGLE_APPLICATION_CREDENTIALS#/app/}"
@@ -55,10 +76,6 @@ if [ -n "$GOOGLE_DRIVE_FOLDER_ID" ] && [ "$GOOGLE_DRIVE_FOLDER_ID" != "your-driv
     if [ -z "$GOOGLE_API_KEY" ] && [ -z "$GOOGLE_GEMINI_API_KEY" ]; then
         echo "⚠️  Warning: Neither GOOGLE_API_KEY nor GOOGLE_GEMINI_API_KEY configured in .env"
     fi
-
-    echo "✓ Google Drive sync directory created"
-else
-    echo "Google Drive integration not configured (skipping gdrive-sync directory)"
 fi
 
 mkdir -p credentials
@@ -83,7 +100,12 @@ sleep 15
 echo "=== Setup complete! ==="
 echo ""
 echo "Next steps:"
-echo "1. Place your Obsidian vault in ./data/vault/"
+if [ -n "$LOCAL_OBSIDIAN_PATH" ]; then
+    echo "1. Obsidian vault configured at: $LOCAL_OBSIDIAN_PATH"
+else
+    echo "1. Place your Obsidian vault in ./data/vault/"
+    echo "   Or set LOCAL_OBSIDIAN_PATH in .env to use an existing vault"
+fi
 echo "2. Access Open WebUI at http://localhost:3000"
 echo "3. Access API docs at http://localhost:8000/docs"
 echo "4. Check health status at http://localhost:8000/health"


### PR DESCRIPTION
- Add LOCAL_OBSIDIAN_PATH environment variable for pointing to existing vaults
- Remove LOCAL_GDRIVE_PATH references (keep only Obsidian path configuration)
- Update docker-compose.yml to mount local Obsidian vault when configured
- Refactor first_run.sh to detect and validate LOCAL_OBSIDIAN_PATH
- Update README with clear instructions for vault configuration
- Maintain backward compatibility with default ./data/vault directory

This allows users to reference their existing Obsidian vault directory instead of copying files, working with any cloud sync solution.