### PR TITLE
Migrate Docker Compose stack to Kubernetes with Flux CD

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,1012 @@
+# Maestro Kubernetes Deployment Guide
+
+This guide provides comprehensive instructions for deploying the Maestro AI Assistant stack to Kubernetes using Kustomize and Flux CD.
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Architecture Overview](#architecture-overview)
+3. [Backend Image Build](#backend-image-build)
+4. [Configuration](#configuration)
+5. [Manual Deployment with Kustomize](#manual-deployment-with-kustomize)
+6. [FluxCD GitOps Setup](#fluxcd-gitops-setup)
+7. [Traefik Ingress Configuration](#traefik-ingress-configuration)
+8. [Verification and Testing](#verification-and-testing)
+9. [Troubleshooting](#troubleshooting)
+10. [Maintenance and Updates](#maintenance-and-updates)
+
+---
+
+## Prerequisites
+
+### Required Software
+
+1. **Kubernetes Cluster** (v1.34.1 or compatible)
+   - kubeadm-based cluster
+   - Minimum: 3 nodes (1 control plane, 2 workers)
+   - Minimum resources per worker: 4 CPU, 8GB RAM
+
+2. **kubectl** (v1.34.x or compatible)
+   ```bash
+   # Verify installation
+   kubectl version --client
+   ```
+
+3. **Kustomize** (v5.0.0 or later)
+   ```bash
+   # Install kustomize
+   curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+   sudo mv kustomize /usr/local/bin/
+
+   # Verify installation
+   kustomize version
+   ```
+
+4. **Flux CLI** (v2.0.0 or later) - For GitOps deployment
+   ```bash
+   # Install Flux CLI
+   curl -s https://fluxcd.io/install.sh | sudo bash
+
+   # Verify installation
+   flux --version
+   ```
+
+5. **Docker or Podman** - For building the backend image
+   ```bash
+   # Verify Docker installation
+   docker --version
+
+   # Or Podman
+   podman --version
+   ```
+
+### Optional Tools
+
+- **Helm** (v3.x) - For Traefik installation if not already present
+- **cert-manager** - For automatic TLS certificate management
+- **k9s** - Terminal UI for easier cluster management
+
+---
+
+## Architecture Overview
+
+The Maestro stack consists of the following components:
+
+### Services
+
+| Service | Type | Purpose | Exposure |
+|---------|------|---------|----------|
+| **PostgreSQL** | Database | Data persistence | Internal (ClusterIP) |
+| **Redis** | Cache | Session & data caching | Internal (ClusterIP) |
+| **MCPO** | MCP Server | Model Context Protocol server | Internal (ClusterIP) |
+| **Backend** | API | Python FastAPI backend | Internal (ClusterIP) |
+| **OpenWebUI** | Frontend | Web interface | External (IngressRoute) |
+
+### Storage Requirements
+
+| PVC Name | Size | Purpose |
+|----------|------|---------|
+| postgres-data | 10Gi | PostgreSQL database |
+| redis-data | 5Gi | Redis persistence |
+| openwebui-data | 10Gi | OpenWebUI data |
+| mcpo-sandbox | 5Gi | MCPO sandbox environment |
+
+### Network Architecture
+
+```
+Internet
+    ↓
+Traefik IngressRoute (maestro.example.com)
+    ↓
+OpenWebUI Service (ClusterIP:8080)
+    ↓
+┌─────────────┐
+│  OpenWebUI  │
+│  Container  │
+└──────┬──────┘
+       │
+       ├─→ Backend Service (ClusterIP:8001)
+       │       ↓
+       │   Backend Container
+       │       ↓
+       ├─→ PostgreSQL Service (ClusterIP:5432)
+       │       ↓
+       │   PostgreSQL Container
+       │       ↓
+       ├─→ Redis Service (ClusterIP:6379)
+       │       ↓
+       │   Redis Container
+       │       ↓
+       └─→ MCPO Service (ClusterIP:8002)
+               ↓
+           MCPO Container
+```
+
+---
+
+## Backend Image Build
+
+The `backend` service requires a pre-built Docker image since it uses a local build context.
+
+### Building the Backend Image
+
+1. **Navigate to the backend directory:**
+   ```bash
+   cd /home/user/Maestro/backend
+   ```
+
+2. **Build the Docker image:**
+   ```bash
+   # Using Docker
+   docker build -t maestro-backend:latest -f ../infra/docker/backend/Dockerfile .
+
+   # Or using Podman
+   podman build -t maestro-backend:latest -f ../infra/docker/backend/Dockerfile .
+   ```
+
+3. **Tag the image for your registry (if using a private registry):**
+   ```bash
+   # Example for Docker Hub
+   docker tag maestro-backend:latest your-dockerhub-username/maestro-backend:latest
+
+   # Example for private registry
+   docker tag maestro-backend:latest registry.example.com/maestro/backend:latest
+   ```
+
+4. **Push the image to your registry:**
+   ```bash
+   # For Docker Hub
+   docker login
+   docker push your-dockerhub-username/maestro-backend:latest
+
+   # For private registry
+   docker login registry.example.com
+   docker push registry.example.com/maestro/backend:latest
+   ```
+
+5. **Update the image reference in the deployment:**
+
+   If using a custom registry, edit `k8s/base/deployment-backend.yaml`:
+   ```yaml
+   spec:
+     containers:
+     - name: backend
+       image: registry.example.com/maestro/backend:latest  # Update this line
+   ```
+
+   Or use Kustomize image transformation in `k8s/base/kustomization.yaml`:
+   ```yaml
+   images:
+     - name: maestro-backend
+       newName: registry.example.com/maestro/backend
+       newTag: latest
+   ```
+
+### Alternative: Load Image Directly (Development/Testing)
+
+For development or testing on a local cluster (kind, minikube, k3s):
+
+```bash
+# For kind
+kind load docker-image maestro-backend:latest --name your-cluster-name
+
+# For minikube
+minikube image load maestro-backend:latest
+
+# For k3s (import to containerd directly)
+docker save maestro-backend:latest | sudo k3s ctr images import -
+```
+
+---
+
+## Configuration
+
+### 1. Update Secrets
+
+**CRITICAL:** Before deploying, update all secret values in `k8s/base/secrets.yaml`.
+
+```bash
+# Generate secure secrets
+openssl rand -hex 32  # For WEBUI_SECRET_KEY
+openssl rand -hex 32  # For JWT_SECRET
+```
+
+Edit `k8s/base/secrets.yaml` and replace all placeholder values:
+- `POSTGRES_PASSWORD`
+- `REDIS_PASSWORD`
+- `MCPO_API_KEY`
+- `WEBUI_SECRET_KEY`
+- `JWT_SECRET`
+- API keys (ANTHROPIC_API_KEY, GOOGLE_API_KEY, etc.)
+
+### 2. Update ConfigMaps
+
+Edit `k8s/base/configmaps.yaml` to customize non-sensitive configuration:
+- `DATABASE_URL` - Update if you changed database credentials
+- `OLLAMA_HOST` - Update if using external Ollama
+- `WEBUI_NAME` - Customize your application name
+- Feature flags and other settings
+
+### 3. Configure Storage
+
+Edit `k8s/base/pvcs.yaml` to adjust storage sizes or add storage class:
+
+```yaml
+spec:
+  storageClassName: your-storage-class  # e.g., "fast-ssd", "nfs-client"
+  resources:
+    requests:
+      storage: 20Gi  # Adjust size as needed
+```
+
+### 4. Configure Ingress
+
+Edit `k8s/base/ingressroute-openwebui.yaml`:
+
+**Update the domain name:**
+```yaml
+spec:
+  routes:
+  - match: Host(`maestro.yourdomain.com`)  # Change this
+```
+
+**For HTTPS with cert-manager:**
+```yaml
+spec:
+  tls:
+    certResolver: letsencrypt
+    # Or use a secret:
+    # secretName: maestro-tls-cert
+```
+
+### 5. Volume Mounts for Backend
+
+The backend service needs access to:
+- Obsidian vault (if applicable)
+- Google credentials (if using Google Cloud)
+
+Choose one of these strategies:
+
+**Option A: HostPath (Development only)**
+```yaml
+volumes:
+- name: vault-data
+  hostPath:
+    path: /path/to/obsidian/vault
+    type: Directory
+```
+
+**Option B: NFS (Recommended for production)**
+```yaml
+volumes:
+- name: vault-data
+  nfs:
+    server: your-nfs-server.example.com
+    path: /exports/obsidian-vault
+```
+
+**Option C: PVC with ReadWriteMany**
+```yaml
+volumes:
+- name: vault-data
+  persistentVolumeClaim:
+    claimName: obsidian-vault
+```
+
+Update `k8s/base/deployment-backend.yaml` accordingly.
+
+---
+
+## Manual Deployment with Kustomize
+
+### 1. Validate the Configuration
+
+```bash
+# Validate Kustomize build
+cd /home/user/Maestro
+kustomize build k8s/ > /tmp/maestro-manifests.yaml
+
+# Review the generated manifests
+less /tmp/maestro-manifests.yaml
+
+# Validate with kubectl
+kubectl apply --dry-run=client -f /tmp/maestro-manifests.yaml
+```
+
+### 2. Deploy to Kubernetes
+
+```bash
+# Apply the manifests
+kubectl apply -k k8s/
+
+# Or use the generated file
+kubectl apply -f /tmp/maestro-manifests.yaml
+```
+
+### 3. Monitor the Deployment
+
+```bash
+# Watch namespace resources
+kubectl get all -n maestro -w
+
+# Check pod status
+kubectl get pods -n maestro
+
+# View logs for specific pod
+kubectl logs -n maestro -f deployment/backend
+kubectl logs -n maestro -f deployment/openwebui
+kubectl logs -n maestro -f deployment/postgres
+
+# Check persistent volume claims
+kubectl get pvc -n maestro
+
+# Check ingress route
+kubectl get ingressroute -n maestro
+```
+
+### 4. Verify Services are Running
+
+```bash
+# Check all deployments are ready
+kubectl get deployments -n maestro
+
+# Expected output:
+# NAME        READY   UP-TO-DATE   AVAILABLE
+# backend     1/1     1            1
+# mcpo        1/1     1            1
+# openwebui   1/1     1            1
+# postgres    1/1     1            1
+# redis       1/1     1            1
+```
+
+---
+
+## FluxCD GitOps Setup
+
+### 1. Install Flux on Your Cluster
+
+```bash
+# Check prerequisites
+flux check --pre
+
+# Bootstrap Flux (GitHub example)
+flux bootstrap github \
+  --owner=your-github-username \
+  --repository=maestro-config \
+  --branch=main \
+  --path=clusters/production \
+  --personal
+```
+
+### 2. Create a GitRepository Resource
+
+Create `flux/gitrepository.yaml`:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: maestro
+  namespace: flux-system
+spec:
+  interval: 1m
+  url: https://github.com/your-org/maestro
+  ref:
+    branch: main
+  # For private repositories:
+  # secretRef:
+  #   name: maestro-git-credentials
+```
+
+Apply it:
+```bash
+kubectl apply -f flux/gitrepository.yaml
+```
+
+### 3. Create a Kustomization Resource
+
+Create `flux/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: maestro
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: ./k8s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: maestro
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: postgres
+      namespace: maestro
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: backend
+      namespace: maestro
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: openwebui
+      namespace: maestro
+  timeout: 10m
+  # Handle dependencies
+  dependsOn:
+    - name: traefik  # If Traefik is managed by Flux
+```
+
+Apply it:
+```bash
+kubectl apply -f flux/kustomization.yaml
+```
+
+### 4. Monitor Flux Reconciliation
+
+```bash
+# Watch Flux resources
+flux get sources git
+flux get kustomizations
+
+# Check reconciliation status
+flux reconcile source git maestro
+flux reconcile kustomization maestro
+
+# View logs
+flux logs --follow --all-namespaces
+```
+
+### 5. Sealed Secrets (For Production)
+
+For production, use Sealed Secrets instead of plain secrets in Git:
+
+```bash
+# Install Sealed Secrets controller
+kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.24.0/controller.yaml
+
+# Install kubeseal CLI
+wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.24.0/kubeseal-0.24.0-linux-amd64.tar.gz
+tar xfz kubeseal-0.24.0-linux-amd64.tar.gz
+sudo install -m 755 kubeseal /usr/local/bin/kubeseal
+
+# Create a sealed secret
+kubectl create secret generic maestro-secrets \
+  --from-literal=POSTGRES_PASSWORD=your-password \
+  --dry-run=client -o yaml | \
+  kubeseal -o yaml > k8s/base/sealed-secrets.yaml
+
+# Replace secrets.yaml with sealed-secrets.yaml in kustomization
+```
+
+---
+
+## Traefik Ingress Configuration
+
+### 1. Install Traefik (if not already installed)
+
+#### Option A: Using Helm
+
+```bash
+# Add Traefik Helm repository
+helm repo add traefik https://traefik.github.io/charts
+helm repo update
+
+# Install Traefik
+helm install traefik traefik/traefik \
+  --namespace traefik \
+  --create-namespace \
+  --set ports.web.expose=true \
+  --set ports.websecure.expose=true \
+  --set ports.websecure.tls.enabled=true
+```
+
+#### Option B: Using Flux
+
+Create `flux/traefik-helmrelease.yaml`:
+
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: traefik
+  namespace: traefik
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: traefik
+      version: '25.0.0'
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: flux-system
+  values:
+    ports:
+      web:
+        expose: true
+      websecure:
+        expose: true
+        tls:
+          enabled: true
+```
+
+### 2. Verify Traefik Installation
+
+```bash
+# Check Traefik pods
+kubectl get pods -n traefik
+
+# Check Traefik service
+kubectl get svc -n traefik
+
+# Get Traefik external IP
+kubectl get svc traefik -n traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
+
+### 3. Configure DNS
+
+Point your domain to the Traefik LoadBalancer IP:
+
+```bash
+# Get the external IP
+TRAEFIK_IP=$(kubectl get svc traefik -n traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+# Create DNS A record
+# maestro.example.com -> $TRAEFIK_IP
+```
+
+### 4. Install cert-manager (for automatic TLS)
+
+```bash
+# Install cert-manager
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/cert-manager.yaml
+
+# Create ClusterIssuer for Let's Encrypt
+cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+    - http01:
+        ingress:
+          class: traefik
+EOF
+```
+
+### 5. Update IngressRoute for TLS
+
+Edit `k8s/base/ingressroute-openwebui.yaml`:
+
+```yaml
+spec:
+  tls:
+    certResolver: letsencrypt-prod
+```
+
+---
+
+## Verification and Testing
+
+### 1. Check Pod Status
+
+```bash
+# All pods should be Running
+kubectl get pods -n maestro
+
+# Check pod events if any issues
+kubectl describe pod -n maestro <pod-name>
+```
+
+### 2. Test Internal Connectivity
+
+```bash
+# Test from OpenWebUI pod to backend
+kubectl exec -n maestro deployment/openwebui -- curl -s http://backend:8001/health
+
+# Test from backend to postgres
+kubectl exec -n maestro deployment/backend -- pg_isready -h postgres -p 5432
+
+# Test from backend to redis
+kubectl exec -n maestro deployment/backend -- redis-cli -h redis -p 6379 ping
+```
+
+### 3. Check Logs
+
+```bash
+# Backend logs
+kubectl logs -n maestro -f deployment/backend
+
+# OpenWebUI logs
+kubectl logs -n maestro -f deployment/openwebui
+
+# PostgreSQL logs
+kubectl logs -n maestro -f deployment/postgres
+
+# Check for errors
+kubectl logs -n maestro deployment/backend | grep -i error
+```
+
+### 4. Test External Access
+
+```bash
+# Test HTTP access
+curl http://maestro.example.com
+
+# Test HTTPS access
+curl https://maestro.example.com
+
+# Check TLS certificate
+openssl s_client -connect maestro.example.com:443 -servername maestro.example.com
+```
+
+### 5. Access the Application
+
+Open your browser and navigate to:
+- HTTP: `http://maestro.example.com`
+- HTTPS: `https://maestro.example.com`
+
+---
+
+## Troubleshooting
+
+### Common Issues and Solutions
+
+#### 1. Pods in CrashLoopBackOff
+
+```bash
+# Check pod logs
+kubectl logs -n maestro <pod-name> --previous
+
+# Check events
+kubectl describe pod -n maestro <pod-name>
+
+# Common causes:
+# - Missing secrets or config
+# - Database not ready (check init containers)
+# - Image pull errors
+```
+
+#### 2. Backend Cannot Connect to Database
+
+```bash
+# Verify database is running
+kubectl get pod -n maestro -l app=postgres
+
+# Check database logs
+kubectl logs -n maestro deployment/postgres
+
+# Verify secret values
+kubectl get secret -n maestro maestro-secrets -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d
+
+# Test connection manually
+kubectl exec -n maestro deployment/postgres -- psql -U maestro -d maestro -c "SELECT 1"
+```
+
+#### 3. Image Pull Errors
+
+```bash
+# Check image pull secrets
+kubectl get pods -n maestro -o jsonpath='{.items[*].spec.imagePullSecrets}'
+
+# For private registries, create image pull secret
+kubectl create secret docker-registry regcred \
+  --docker-server=registry.example.com \
+  --docker-username=your-username \
+  --docker-password=your-password \
+  --docker-email=your-email@example.com \
+  -n maestro
+
+# Add to deployment
+# spec:
+#   imagePullSecrets:
+#   - name: regcred
+```
+
+#### 4. PVC Not Binding
+
+```bash
+# Check PVC status
+kubectl get pvc -n maestro
+
+# Check PV availability
+kubectl get pv
+
+# Check storage classes
+kubectl get storageclass
+
+# Describe PVC for events
+kubectl describe pvc -n maestro postgres-data
+
+# Solution: Specify correct storageClassName in pvcs.yaml
+```
+
+#### 5. Ingress Not Working
+
+```bash
+# Check IngressRoute status
+kubectl get ingressroute -n maestro
+
+# Check Traefik logs
+kubectl logs -n traefik deployment/traefik
+
+# Verify Traefik can see the IngressRoute
+kubectl get ingressroute -n maestro -o yaml
+
+# Check middleware
+kubectl get middleware -n maestro
+```
+
+#### 6. Service Not Accessible
+
+```bash
+# Check service endpoints
+kubectl get endpoints -n maestro
+
+# Verify label selectors match
+kubectl get pods -n maestro --show-labels
+kubectl get svc -n maestro openwebui -o yaml | grep selector -A 3
+
+# Test service from another pod
+kubectl run -it --rm debug --image=alpine --restart=Never -- sh
+# Inside the pod:
+# wget -O- http://openwebui.maestro.svc.cluster.local:8080
+```
+
+### Debug Commands Reference
+
+```bash
+# Get all resources in namespace
+kubectl get all -n maestro
+
+# Describe all resources
+kubectl describe all -n maestro
+
+# Get events sorted by time
+kubectl get events -n maestro --sort-by='.lastTimestamp'
+
+# Port forward for local testing
+kubectl port-forward -n maestro svc/openwebui 8080:8080
+# Then access http://localhost:8080
+
+# Execute shell in pod
+kubectl exec -it -n maestro deployment/backend -- /bin/bash
+
+# Copy files from/to pod
+kubectl cp maestro/backend-pod:/app/logs/app.log ./local-app.log
+
+# Check resource usage
+kubectl top pods -n maestro
+kubectl top nodes
+```
+
+---
+
+## Maintenance and Updates
+
+### Updating Application Images
+
+#### Manual Update
+
+```bash
+# Update image in deployment
+kubectl set image deployment/backend backend=maestro-backend:v2.0.0 -n maestro
+
+# Or patch the deployment
+kubectl patch deployment backend -n maestro -p '{"spec":{"template":{"spec":{"containers":[{"name":"backend","image":"maestro-backend:v2.0.0"}]}}}}'
+
+# Restart deployment
+kubectl rollout restart deployment/backend -n maestro
+```
+
+#### With Kustomize
+
+Update `k8s/base/kustomization.yaml`:
+```yaml
+images:
+  - name: maestro-backend
+    newName: registry.example.com/maestro/backend
+    newTag: v2.0.0
+```
+
+Apply:
+```bash
+kubectl apply -k k8s/
+```
+
+#### With Flux (GitOps)
+
+Commit and push changes to your Git repository. Flux will automatically apply them:
+```bash
+git add k8s/base/kustomization.yaml
+git commit -m "Update backend image to v2.0.0"
+git push origin main
+
+# Force immediate reconciliation
+flux reconcile source git maestro
+flux reconcile kustomization maestro
+```
+
+### Scaling Services
+
+```bash
+# Scale OpenWebUI for high availability
+kubectl scale deployment openwebui --replicas=3 -n maestro
+
+# Scale backend
+kubectl scale deployment backend --replicas=2 -n maestro
+
+# View current replicas
+kubectl get deployment -n maestro
+```
+
+### Backup and Restore
+
+#### PostgreSQL Backup
+
+```bash
+# Create backup
+kubectl exec -n maestro deployment/postgres -- pg_dump -U maestro maestro > maestro-backup-$(date +%Y%m%d).sql
+
+# Or use a CronJob for automated backups
+cat <<EOF | kubectl apply -f -
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-backup
+  namespace: maestro
+spec:
+  schedule: "0 2 * * *"  # Daily at 2 AM
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: backup
+            image: postgres:16-alpine
+            command:
+            - /bin/sh
+            - -c
+            - pg_dump -h postgres -U \$POSTGRES_USER \$POSTGRES_DB > /backup/maestro-\$(date +%Y%m%d-%H%M%S).sql
+            env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: maestro-secrets
+                  key: POSTGRES_USER
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: maestro-secrets
+                  key: POSTGRES_DB
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: maestro-secrets
+                  key: POSTGRES_PASSWORD
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+          restartPolicy: OnFailure
+          volumes:
+          - name: backup
+            persistentVolumeClaim:
+              claimName: postgres-backup
+EOF
+```
+
+#### PostgreSQL Restore
+
+```bash
+# Restore from backup
+kubectl cp maestro-backup-20250101.sql maestro/postgres-pod:/tmp/backup.sql
+kubectl exec -n maestro deployment/postgres -- psql -U maestro maestro < /tmp/backup.sql
+```
+
+### Monitoring
+
+#### Install Prometheus and Grafana (Optional)
+
+```bash
+# Add Prometheus Helm repo
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+# Install kube-prometheus-stack
+helm install prometheus prometheus-community/kube-prometheus-stack \
+  --namespace monitoring \
+  --create-namespace
+
+# Access Grafana
+kubectl port-forward -n monitoring svc/prometheus-grafana 3000:80
+# Username: admin, Password: prom-operator
+```
+
+### Uninstalling
+
+```bash
+# Delete all resources
+kubectl delete -k k8s/
+
+# Or delete namespace (which deletes all resources)
+kubectl delete namespace maestro
+
+# Delete PVCs (if needed)
+kubectl delete pvc -n maestro --all
+
+# Note: This will DELETE ALL DATA
+```
+
+---
+
+## Security Best Practices
+
+1. **Always use secrets management:**
+   - Use Sealed Secrets or external secrets operators
+   - Never commit plain secrets to Git
+
+2. **Enable network policies:**
+   ```yaml
+   apiVersion: networking.k8s.io/v1
+   kind: NetworkPolicy
+   metadata:
+     name: maestro-network-policy
+     namespace: maestro
+   spec:
+     podSelector: {}
+     policyTypes:
+     - Ingress
+     - Egress
+     ingress:
+     - from:
+       - namespaceSelector:
+           matchLabels:
+             name: maestro
+   ```
+
+3. **Use resource limits:**
+   - Already configured in deployments
+   - Adjust based on your workload
+
+4. **Enable Pod Security Standards:**
+   ```bash
+   kubectl label namespace maestro pod-security.kubernetes.io/enforce=baseline
+   ```
+
+5. **Regular updates:**
+   - Keep images up to date
+   - Monitor for security vulnerabilities
+   - Use image scanning tools
+
+---
+
+## Additional Resources
+
+- [Kubernetes Documentation](https://kubernetes.io/docs/)
+- [Kustomize Documentation](https://kustomize.io/)
+- [Flux CD Documentation](https://fluxcd.io/docs/)
+- [Traefik Documentation](https://doc.traefik.io/traefik/)
+- [PostgreSQL on Kubernetes](https://www.postgresql.org/docs/)
+
+---
+
+## Support and Contributing
+
+For issues or questions:
+1. Check the [troubleshooting section](#troubleshooting)
+2. Review pod logs and events
+3. Open an issue in the project repository
+
+---
+
+**Last Updated:** 2025-11-15
+**Version:** 1.0.0

--- a/k8s/base/configmaps.yaml
+++ b/k8s/base/configmaps.yaml
@@ -1,0 +1,205 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maestro-config
+  namespace: maestro
+data:
+  # Database connection strings (non-sensitive parts)
+  DATABASE_URL: "postgresql://maestro:change_me_in_production@postgres:5432/maestro"
+
+  # Ollama configuration
+  OLLAMA_HOST: "http://ollama:11434"
+  OLLAMA_MODEL: "llama3:8b"
+
+  # Backend configuration
+  BACKEND_HOST: "0.0.0.0"
+  BACKEND_PORT: "8000"
+  LOG_LEVEL: "INFO"
+
+  # Security
+  JWT_ALGORITHM: "HS256"
+  JWT_EXPIRATION_HOURS: "24"
+  ALLOWED_ORIGINS: "http://localhost:3000,http://localhost:8000"
+
+  # Path mapping configuration
+  OBSIDIAN_VAULT_PATH: "/app/data/vault"
+  GDRIVE_SYNC_PATH: "/app/data/gdrive-sync"
+  GOOGLE_APPLICATION_CREDENTIALS: "/app/credentials/google-credentials.json"
+
+  # Feature flags
+  ENABLE_PROACTIVE_SUGGESTIONS: "true"
+  ENABLE_HITL_CONFIRMATIONS: "true"
+  ENABLE_USER_BEHAVIOR_MODELING: "false"
+  ENABLE_SIGNUP: "true"
+
+  # Open WebUI configuration
+  WEBUI_NAME: "Maestro AI Assistant"
+  WEBUI_PORT: "3000"
+
+  # Node environment
+  NODE_ENV: "production"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init
+  namespace: maestro
+data:
+  init.sql: |
+    -- Maestro Database Initialization
+
+    -- Extensions
+    CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+    CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+
+    -- Path Mapping Table
+    CREATE TABLE IF NOT EXISTS path_mappings (
+        id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        local_path TEXT NOT NULL UNIQUE,
+        cloud_path TEXT NOT NULL,
+        cloud_id TEXT,
+        cloud_provider VARCHAR(50) NOT NULL DEFAULT 'google_drive',
+        file_type VARCHAR(50),
+        last_synced_at TIMESTAMP WITH TIME ZONE,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE INDEX idx_path_mappings_local ON path_mappings(local_path);
+    CREATE INDEX idx_path_mappings_cloud_id ON path_mappings(cloud_id);
+
+    -- User Preferences Table
+    CREATE TABLE IF NOT EXISTS user_preferences (
+        id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        user_id VARCHAR(255) NOT NULL UNIQUE,
+        preferences JSONB NOT NULL DEFAULT '{}',
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+
+    -- User Behavior Events Table
+    CREATE TABLE IF NOT EXISTS user_behavior_events (
+        id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        user_id VARCHAR(255) NOT NULL,
+        event_type VARCHAR(100) NOT NULL,
+        event_data JSONB NOT NULL,
+        context JSONB,
+        timestamp TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE INDEX idx_behavior_events_user_id ON user_behavior_events(user_id);
+    CREATE INDEX idx_behavior_events_type ON user_behavior_events(event_type);
+    CREATE INDEX idx_behavior_events_timestamp ON user_behavior_events(timestamp DESC);
+
+    -- Task Table
+    CREATE TABLE IF NOT EXISTS tasks (
+        id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        user_id VARCHAR(255) NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT,
+        status VARCHAR(50) DEFAULT 'pending',
+        priority VARCHAR(20) DEFAULT 'medium',
+        source_type VARCHAR(100),
+        source_id TEXT,
+        due_date TIMESTAMP WITH TIME ZONE,
+        completed_at TIMESTAMP WITH TIME ZONE,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE INDEX idx_tasks_user_id ON tasks(user_id);
+    CREATE INDEX idx_tasks_status ON tasks(status);
+    CREATE INDEX idx_tasks_due_date ON tasks(due_date);
+
+    -- Proactive Suggestions Table
+    CREATE TABLE IF NOT EXISTS proactive_suggestions (
+        id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        user_id VARCHAR(255) NOT NULL,
+        suggestion_type VARCHAR(100) NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT,
+        action_data JSONB NOT NULL,
+        confidence_score FLOAT,
+        status VARCHAR(50) DEFAULT 'pending',
+        user_response VARCHAR(50),
+        responded_at TIMESTAMP WITH TIME ZONE,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE INDEX idx_suggestions_user_id ON proactive_suggestions(user_id);
+    CREATE INDEX idx_suggestions_status ON proactive_suggestions(status);
+
+    -- Chat History Table (supplementary to Open WebUI's)
+    CREATE TABLE IF NOT EXISTS chat_sessions (
+        id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        user_id VARCHAR(255) NOT NULL,
+        session_data JSONB NOT NULL,
+        active BOOLEAN DEFAULT true,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+
+    -- Workflow Automation Rules Table
+    CREATE TABLE IF NOT EXISTS automation_rules (
+        id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+        user_id VARCHAR(255) NOT NULL,
+        rule_name VARCHAR(255) NOT NULL,
+        trigger_type VARCHAR(100) NOT NULL,
+        trigger_config JSONB NOT NULL,
+        action_type VARCHAR(100) NOT NULL,
+        action_config JSONB NOT NULL,
+        enabled BOOLEAN DEFAULT true,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    );
+
+    -- Update triggers for updated_at columns
+    CREATE OR REPLACE FUNCTION update_updated_at_column()
+    RETURNS TRIGGER AS $$
+    BEGIN
+        NEW.updated_at = CURRENT_TIMESTAMP;
+        RETURN NEW;
+    END;
+    $$ language 'plpgsql';
+
+    CREATE TRIGGER update_path_mappings_updated_at BEFORE UPDATE ON path_mappings
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+    CREATE TRIGGER update_user_preferences_updated_at BEFORE UPDATE ON user_preferences
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+    CREATE TRIGGER update_tasks_updated_at BEFORE UPDATE ON tasks
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+    CREATE TRIGGER update_chat_sessions_updated_at BEFORE UPDATE ON chat_sessions
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+    CREATE TRIGGER update_automation_rules_updated_at BEFORE UPDATE ON automation_rules
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcpo-config
+  namespace: maestro
+data:
+  multi-server.json: |
+    {
+      "mcpServers": {
+        "memory": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-memory"]
+        },
+        "time": {
+          "command": "uvx",
+          "args": ["mcp-server-time", "--local-timezone=America/Chicago"]
+        },
+        "filesystem": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "--allowed-directories", "./sandbox"]
+        }
+      }
+    }

--- a/k8s/base/deployment-backend.yaml
+++ b/k8s/base/deployment-backend.yaml
@@ -1,0 +1,169 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: maestro
+  labels:
+    app: backend
+    component: api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+        component: api
+    spec:
+      initContainers:
+      - name: wait-for-postgres
+        image: postgres:16-alpine
+        command:
+        - sh
+        - -c
+        - |
+          until pg_isready -h postgres -p 5432 -U $POSTGRES_USER; do
+            echo "Waiting for postgres..."
+            sleep 2
+          done
+          echo "Postgres is ready!"
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: maestro-secrets
+              key: POSTGRES_USER
+      containers:
+      - name: backend
+        image: maestro-backend:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8001
+          name: http
+        command:
+        - uvicorn
+        - api.main:app
+        - --host
+        - "0.0.0.0"
+        - --port
+        - "8001"
+        - --reload
+        env:
+        # Database configuration
+        - name: DATABASE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: maestro-config
+              key: DATABASE_URL
+
+        # Ollama configuration
+        - name: OLLAMA_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: maestro-config
+              key: OLLAMA_HOST
+        - name: OLLAMA_MODEL
+          valueFrom:
+            configMapKeyRef:
+              name: maestro-config
+              key: OLLAMA_MODEL
+
+        # Path configuration
+        - name: OBSIDIAN_VAULT_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: maestro-config
+              key: OBSIDIAN_VAULT_PATH
+        - name: GDRIVE_SYNC_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: maestro-config
+              key: GDRIVE_SYNC_PATH
+
+        # Google Cloud configuration
+        - name: GOOGLE_CLOUD_PROJECT
+          valueFrom:
+            secretKeyRef:
+              name: maestro-secrets
+              key: GOOGLE_CLOUD_PROJECT
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          valueFrom:
+            configMapKeyRef:
+              name: maestro-config
+              key: GOOGLE_APPLICATION_CREDENTIALS
+        - name: GOOGLE_DRIVE_FOLDER_ID
+          valueFrom:
+            secretKeyRef:
+              name: maestro-secrets
+              key: GOOGLE_DRIVE_FOLDER_ID
+
+        # Logging
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: maestro-config
+              key: LOG_LEVEL
+
+        volumeMounts:
+        # Note: These volumes need to be configured based on your storage setup
+        # Option 1: Use hostPath for development
+        # Option 2: Use NFS or other shared storage for production
+        # Option 3: Use PVCs (commented out in pvcs.yaml)
+
+        # Uncomment and configure based on your storage strategy:
+        # - name: vault-data
+        #   mountPath: /app/data/vault
+        #   readOnly: true
+        # - name: credentials
+        #   mountPath: /app/credentials
+        #   readOnly: true
+
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+          limits:
+            memory: "2Gi"
+            cpu: "2000m"
+
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8001
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8001
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+      volumes:
+      # Configure these volumes based on your storage strategy
+      # Example using hostPath (NOT recommended for production):
+      # - name: vault-data
+      #   hostPath:
+      #     path: /path/to/obsidian/vault
+      #     type: Directory
+      # - name: credentials
+      #   hostPath:
+      #     path: /path/to/credentials
+      #     type: Directory
+
+      # Example using NFS (recommended for production):
+      # - name: vault-data
+      #   nfs:
+      #     server: your-nfs-server
+      #     path: /exports/obsidian-vault
+      # - name: credentials
+      #   secret:
+      #     secretName: google-credentials

--- a/k8s/base/deployment-mcpo.yaml
+++ b/k8s/base/deployment-mcpo.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcpo
+  namespace: maestro
+  labels:
+    app: mcpo
+    component: mcp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcpo
+  template:
+    metadata:
+      labels:
+        app: mcpo
+        component: mcp-server
+    spec:
+      containers:
+      - name: mcpo
+        image: ghcr.io/open-webui/mcpo:main
+        ports:
+        - containerPort: 8002
+          name: http
+        command:
+        - mcpo
+        - --host
+        - "0.0.0.0"
+        - --port
+        - "8002"
+        - --api-key
+        - "$(MCPO_API_KEY)"
+        - --config
+        - /config/multi-server.json
+        env:
+        - name: MCPO_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: maestro-secrets
+              key: MCPO_API_KEY
+        - name: NODE_ENV
+          valueFrom:
+            configMapKeyRef:
+              name: maestro-config
+              key: NODE_ENV
+        volumeMounts:
+        - name: config
+          mountPath: /config
+          readOnly: true
+        - name: sandbox
+          mountPath: /app/sandbox
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "1000m"
+        livenessProbe:
+          httpGet:
+            path: /docs
+            port: 8002
+          initialDelaySeconds: 40
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /docs
+            port: 8002
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+      volumes:
+      - name: config
+        configMap:
+          name: mcpo-config
+      - name: sandbox
+        persistentVolumeClaim:
+          claimName: mcpo-sandbox

--- a/k8s/base/deployment-openwebui.yaml
+++ b/k8s/base/deployment-openwebui.yaml
@@ -1,0 +1,132 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openwebui
+  namespace: maestro
+  labels:
+    app: openwebui
+    component: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openwebui
+  template:
+    metadata:
+      labels:
+        app: openwebui
+        component: frontend
+    spec:
+      initContainers:
+      - name: wait-for-postgres
+        image: postgres:16-alpine
+        command:
+        - sh
+        - -c
+        - |
+          until pg_isready -h postgres -p 5432 -U $POSTGRES_USER; do
+            echo "Waiting for postgres..."
+            sleep 2
+          done
+          echo "Postgres is ready!"
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: maestro-secrets
+              key: POSTGRES_USER
+      containers:
+      - name: openwebui
+        image: ghcr.io/open-webui/open-webui:main
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        # WebUI secret key
+        - name: WEBUI_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: maestro-secrets
+              key: WEBUI_SECRET_KEY
+
+        # Ollama configuration
+        - name: OLLAMA_BASE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: maestro-config
+              key: OLLAMA_HOST
+
+        # Database URL (constructed from secrets)
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: maestro-secrets
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: maestro-secrets
+              key: POSTGRES_PASSWORD
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: maestro-secrets
+              key: POSTGRES_DB
+        - name: DATABASE_URL
+          value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres:5432/$(POSTGRES_DB)"
+
+        # WebUI configuration
+        - name: ENABLE_SIGNUP
+          valueFrom:
+            configMapKeyRef:
+              name: maestro-config
+              key: ENABLE_SIGNUP
+        - name: WEBUI_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: maestro-config
+              key: WEBUI_NAME
+
+        volumeMounts:
+        - name: webui-data
+          mountPath: /app/backend/data
+        # Uncomment if you have custom frontend files
+        # - name: customizations
+        #   mountPath: /app/backend/data/customizations
+
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+          limits:
+            memory: "2Gi"
+            cpu: "2000m"
+
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+      volumes:
+      - name: webui-data
+        persistentVolumeClaim:
+          claimName: openwebui-data
+      # Uncomment and configure if you have custom frontend files:
+      # - name: customizations
+      #   hostPath:
+      #     path: /path/to/frontend/open-webui-customizations
+      #     type: Directory

--- a/k8s/base/deployment-postgres.yaml
+++ b/k8s/base/deployment-postgres.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: maestro
+  labels:
+    app: postgres
+    component: database
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate  # Important for databases to avoid multiple instances
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+        component: database
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:16-alpine
+        ports:
+        - containerPort: 5432
+          name: postgres
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: maestro-secrets
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: maestro-secrets
+              key: POSTGRES_PASSWORD
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: maestro-secrets
+              key: POSTGRES_DB
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        volumeMounts:
+        - name: postgres-data
+          mountPath: /var/lib/postgresql/data
+        - name: init-script
+          mountPath: /docker-entrypoint-initdb.d
+          readOnly: true
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "1000m"
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - pg_isready -U $POSTGRES_USER
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - pg_isready -U $POSTGRES_USER
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 5
+      volumes:
+      - name: postgres-data
+        persistentVolumeClaim:
+          claimName: postgres-data
+      - name: init-script
+        configMap:
+          name: postgres-init

--- a/k8s/base/deployment-redis.yaml
+++ b/k8s/base/deployment-redis.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: maestro
+  labels:
+    app: redis
+    component: cache
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        component: cache
+    spec:
+      containers:
+      - name: redis
+        image: redis:7-alpine
+        ports:
+        - containerPort: 6379
+          name: redis
+        command:
+        - redis-server
+        - --appendonly
+        - "yes"
+        - --requirepass
+        - "$(REDIS_PASSWORD)"
+        env:
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: maestro-secrets
+              key: REDIS_PASSWORD
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        livenessProbe:
+          exec:
+            command:
+            - redis-cli
+            - --raw
+            - incr
+            - ping
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+        readinessProbe:
+          exec:
+            command:
+            - redis-cli
+            - --raw
+            - incr
+            - ping
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+      volumes:
+      - name: redis-data
+        persistentVolumeClaim:
+          claimName: redis-data

--- a/k8s/base/ingressroute-openwebui.yaml
+++ b/k8s/base/ingressroute-openwebui.yaml
@@ -1,0 +1,98 @@
+---
+# Traefik IngressRoute for OpenWebUI
+# This assumes Traefik v2/v3 is installed as the ingress controller
+# Make sure to update the Host rule with your actual domain
+
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: openwebui
+  namespace: maestro
+  labels:
+    app: openwebui
+spec:
+  entryPoints:
+    - web      # HTTP (port 80)
+    - websecure  # HTTPS (port 443)
+  routes:
+  - match: Host(`maestro.example.com`)  # UPDATE THIS with your actual domain
+    kind: Rule
+    services:
+    - name: openwebui
+      port: 8080
+    middlewares:
+    - name: openwebui-headers
+  # Uncomment the tls section if you want to enable HTTPS with cert-manager
+  # tls:
+  #   certResolver: letsencrypt  # or your cert resolver name
+  #   # OR use a predefined certificate:
+  #   # secretName: maestro-tls-cert
+
+---
+# Middleware for security headers and other configurations
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: openwebui-headers
+  namespace: maestro
+spec:
+  headers:
+    customRequestHeaders:
+      X-Forwarded-Proto: "https"
+    customResponseHeaders:
+      X-Frame-Options: "SAMEORIGIN"
+      X-Content-Type-Options: "nosniff"
+      X-XSS-Protection: "1; mode=block"
+    sslRedirect: false  # Set to true if you want to force HTTPS
+    # browserXssFilter: true
+    # contentTypeNosniff: true
+    # forceSTSHeader: true
+    # stsIncludeSubdomains: true
+    # stsPreload: true
+    # stsSeconds: 31536000
+
+---
+# Optional: HTTP to HTTPS redirect middleware
+# Uncomment this and add it to the IngressRoute if you want to force HTTPS
+# apiVersion: traefik.io/v1alpha1
+# kind: Middleware
+# metadata:
+#   name: redirect-https
+#   namespace: maestro
+# spec:
+#   redirectScheme:
+#     scheme: https
+#     permanent: true
+
+---
+# Alternative: Standard Kubernetes Ingress (if not using Traefik CRDs)
+# Uncomment this section if you prefer to use standard Kubernetes Ingress
+# and comment out the IngressRoute above
+
+# apiVersion: networking.k8s.io/v1
+# kind: Ingress
+# metadata:
+#   name: openwebui
+#   namespace: maestro
+#   annotations:
+#     kubernetes.io/ingress.class: traefik
+#     # For automatic HTTPS with cert-manager:
+#     # cert-manager.io/cluster-issuer: letsencrypt-prod
+#     # traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+#     # traefik.ingress.kubernetes.io/router.middlewares: maestro-openwebui-headers@kubernetescrd
+# spec:
+#   rules:
+#   - host: maestro.example.com  # UPDATE THIS
+#     http:
+#       paths:
+#       - path: /
+#         pathType: Prefix
+#         backend:
+#           service:
+#             name: openwebui
+#             port:
+#               number: 8080
+#   # tls:
+#   # - hosts:
+#   #   - maestro.example.com
+#   #   secretName: maestro-tls-cert

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,49 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: maestro
+
+resources:
+  # Namespace
+  - namespace.yaml
+
+  # Configuration
+  - secrets.yaml
+  - configmaps.yaml
+
+  # Storage
+  - pvcs.yaml
+
+  # PostgreSQL
+  - deployment-postgres.yaml
+  - service-postgres.yaml
+
+  # Redis
+  - deployment-redis.yaml
+  - service-redis.yaml
+
+  # MCPO
+  - deployment-mcpo.yaml
+  - service-mcpo.yaml
+
+  # Backend API
+  - deployment-backend.yaml
+  - service-backend.yaml
+
+  # Open WebUI
+  - deployment-openwebui.yaml
+  - service-openwebui.yaml
+
+  # Ingress
+  - ingressroute-openwebui.yaml
+
+# Common labels applied to all resources
+commonLabels:
+  app.kubernetes.io/name: maestro
+  app.kubernetes.io/part-of: maestro-stack
+
+# Images that can be customized via kustomize
+# images:
+#   - name: maestro-backend
+#     newName: your-registry/maestro-backend
+#     newTag: v1.0.0

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: maestro
+  labels:
+    app: maestro
+    toolkit.fluxcd.io/tenant: maestro

--- a/k8s/base/pvcs.yaml
+++ b/k8s/base/pvcs.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  namespace: maestro
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  # storageClassName: default  # Uncomment and specify your storage class if needed
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-data
+  namespace: maestro
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  # storageClassName: default
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openwebui-data
+  namespace: maestro
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  # storageClassName: default
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mcpo-sandbox
+  namespace: maestro
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  # storageClassName: default
+
+---
+# Optional: PVC for Obsidian vault (if not using external NFS/host path)
+# Uncomment if you want to use a PVC for the Obsidian vault
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: obsidian-vault
+#   namespace: maestro
+# spec:
+#   accessModes:
+#     - ReadWriteMany  # Multiple pods might need to read this
+#   resources:
+#     requests:
+#       storage: 5Gi
+#   # storageClassName: nfs-client  # Consider using NFS for shared access

--- a/k8s/base/secrets.yaml
+++ b/k8s/base/secrets.yaml
@@ -1,0 +1,38 @@
+---
+# IMPORTANT: Before deploying, encode all values using base64:
+# echo -n "your-value" | base64
+# These are placeholder values and MUST be updated before deployment
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: maestro-secrets
+  namespace: maestro
+type: Opaque
+stringData:
+  # Database credentials
+  POSTGRES_USER: maestro
+  POSTGRES_PASSWORD: change_me_in_production
+  POSTGRES_DB: maestro
+
+  # Redis credentials
+  REDIS_PASSWORD: changeme
+
+  # MCPO API Key
+  MCPO_API_KEY: mcpo-secret-key
+
+  # Open WebUI Secret Key
+  # Generate with: openssl rand -hex 32
+  WEBUI_SECRET_KEY: generate-a-random-secret-key
+
+  # JWT Secret
+  JWT_SECRET: generate-a-random-jwt-secret
+
+  # API Keys (add your actual keys here)
+  ANTHROPIC_API_KEY: your_anthropic_api_key_here
+  GOOGLE_API_KEY: your_google_api_key_here
+  GOOGLE_GEMINI_API_KEY: your_gemini_api_key_here
+
+  # Google Cloud credentials (if applicable)
+  GOOGLE_CLOUD_PROJECT: your-project-id
+  GOOGLE_DRIVE_FOLDER_ID: your-drive-folder-id

--- a/k8s/base/service-backend.yaml
+++ b/k8s/base/service-backend.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: maestro
+  labels:
+    app: backend
+    component: api
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8001
+    targetPort: 8001
+    protocol: TCP
+    name: http
+  selector:
+    app: backend

--- a/k8s/base/service-mcpo.yaml
+++ b/k8s/base/service-mcpo.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcpo
+  namespace: maestro
+  labels:
+    app: mcpo
+    component: mcp-server
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8002
+    targetPort: 8002
+    protocol: TCP
+    name: http
+  selector:
+    app: mcpo

--- a/k8s/base/service-openwebui.yaml
+++ b/k8s/base/service-openwebui.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openwebui
+  namespace: maestro
+  labels:
+    app: openwebui
+    component: frontend
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: openwebui

--- a/k8s/base/service-postgres.yaml
+++ b/k8s/base/service-postgres.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: maestro
+  labels:
+    app: postgres
+    component: database
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+    targetPort: 5432
+    protocol: TCP
+    name: postgres
+  selector:
+    app: postgres

--- a/k8s/base/service-redis.yaml
+++ b/k8s/base/service-redis.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: maestro
+  labels:
+    app: redis
+    component: cache
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+    protocol: TCP
+    name: redis
+  selector:
+    app: redis

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Reference to base manifests
+resources:
+  - base
+
+# You can add overlays, patches, or customizations here
+# For example, to use different configurations for dev/staging/prod:
+#
+# For development:
+# patchesStrategicMerge:
+#   - overlays/dev/patch-replicas.yaml
+#
+# For production:
+# patchesStrategicMerge:
+#   - overlays/prod/patch-replicas.yaml
+#   - overlays/prod/patch-resources.yaml


### PR DESCRIPTION
This commit adds a complete Kubernetes deployment structure for the Maestro AI Assistant stack, migrating from Docker Compose to Kubernetes with Kustomize and Flux CD support.

Components added:
- Namespace and Kustomize structure
- Secrets and ConfigMaps for all environment variables
- PersistentVolumeClaims for PostgreSQL, Redis, OpenWebUI, and MCPO
- Deployment and Service manifests for:
  * PostgreSQL (with init.sql ConfigMap)
  * Redis (with password authentication)
  * MCPO (MCP server with config)
  * Backend API (FastAPI with health checks)
  * OpenWebUI (frontend with dependencies)
- Traefik IngressRoute and Middleware for external access
- Comprehensive deployment documentation

Key features:
- Production-ready health checks and resource limits
- Init containers for service dependencies
- ConfigMap-based configuration management
- Support for both manual and GitOps deployment
- Detailed documentation covering:
  * Prerequisites and architecture
  * Backend image build instructions
  * Manual deployment with Kustomize
  * FluxCD GitOps setup
  * Traefik ingress configuration
  * Verification, testing, and troubleshooting
  * Maintenance and updates

All services use ClusterIP except OpenWebUI which is exposed via Traefik IngressRoute as per requirements.