### PR TITLE
feat: Add GitHub Actions workflow for Terraform deployment

### DIFF
--- a/.github/workflows/SETUP.md
+++ b/.github/workflows/SETUP.md
@@ -1,0 +1,273 @@
+# GitHub Actions Terraform Setup Guide
+
+This guide will help you set up the required secrets and permissions for the Terraform GitHub Actions workflow.
+
+## Required GitHub Secrets
+
+Navigate to your repository's **Settings > Secrets and variables > Actions** and add the following secrets:
+
+### 1. GCP Authentication
+
+Choose **ONE** of the following authentication methods:
+
+#### Option A: Service Account Key (Simpler, Less Secure)
+
+1. Create a service account in GCP:
+```bash
+gcloud iam service-accounts create github-actions-terraform \
+  --display-name="GitHub Actions Terraform"
+```
+
+2. Grant necessary permissions:
+```bash
+PROJECT_ID="your-project-id"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:github-actions-terraform@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/cloudfunctions.admin"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:github-actions-terraform@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountUser"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:github-actions-terraform@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/storage.admin"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:github-actions-terraform@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/cloudbuild.builds.editor"
+```
+
+3. Create and download the key:
+```bash
+gcloud iam service-accounts keys create github-actions-key.json \
+  --iam-account=github-actions-terraform@${PROJECT_ID}.iam.gserviceaccount.com
+```
+
+4. Add to GitHub Secrets:
+   - Secret name: `GCP_CREDENTIALS`
+   - Secret value: Contents of `github-actions-key.json`
+
+5. **Important**: Delete the local key file after uploading:
+```bash
+rm github-actions-key.json
+```
+
+#### Option B: Workload Identity Federation (Recommended for Production)
+
+1. Create a Workload Identity Pool:
+```bash
+PROJECT_ID="your-project-id"
+PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)")
+
+gcloud iam workload-identity-pools create "github-actions" \
+  --project="${PROJECT_ID}" \
+  --location="global" \
+  --display-name="GitHub Actions"
+```
+
+2. Create a Workload Identity Provider:
+```bash
+REPO_OWNER="your-github-username"
+REPO_NAME="your-repo-name"
+
+gcloud iam workload-identity-pools providers create-oidc "github" \
+  --project="${PROJECT_ID}" \
+  --location="global" \
+  --workload-identity-pool="github-actions" \
+  --display-name="GitHub" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+```
+
+3. Create a service account:
+```bash
+gcloud iam service-accounts create github-actions-terraform \
+  --display-name="GitHub Actions Terraform"
+```
+
+4. Grant permissions (same as Option A above)
+
+5. Allow GitHub Actions to impersonate the service account:
+```bash
+gcloud iam service-accounts add-iam-policy-binding \
+  "github-actions-terraform@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --project="${PROJECT_ID}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github-actions/attribute.repository/${REPO_OWNER}/${REPO_NAME}"
+```
+
+6. Add to GitHub Secrets:
+   - Secret name: `GCP_WORKLOAD_IDENTITY_PROVIDER`
+   - Secret value: `projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github-actions/providers/github`
+
+   - Secret name: `GCP_SERVICE_ACCOUNT`
+   - Secret value: `github-actions-terraform@${PROJECT_ID}.iam.gserviceaccount.com`
+
+7. Update `.github/workflows/terraform.yml`:
+   - Comment out the "Service Account Key" section
+   - Uncomment the "Workload Identity" section
+
+### 2. GCP Project Configuration
+
+- **Secret name**: `GCP_PROJECT_ID`
+- **Secret value**: Your GCP project ID (e.g., `my-project-12345`)
+
+### 3. GitHub Token
+
+- **Secret name**: `GH_TOKEN`
+- **Secret value**: Your GitHub Personal Access Token
+
+  To create a token:
+  1. Go to GitHub Settings > Developer settings > Personal access tokens > Tokens (classic)
+  2. Generate new token with `repo` scope
+  3. Copy the token value
+
+### 4. Repository Name
+
+- **Secret name**: `REPO_NAME`
+- **Secret value**: Your repository in format `username/repo` (e.g., `lordmuffin/Maestro`)
+
+## Workflow Features
+
+### Automatic Triggers
+
+1. **Pull Requests**: Runs `terraform plan` and comments the plan on the PR
+2. **Push to Main**: Runs `terraform apply` automatically
+3. **Manual Trigger**: Use "Run workflow" button with options for plan/apply/destroy
+
+### Security Scanning
+
+The workflow includes two security scanners that run on PRs:
+- **tfsec**: Scans for security issues in Terraform code
+- **Checkov**: Validates infrastructure-as-code security and compliance
+
+### Workflow Outputs
+
+After successful deployment, the workflow will display:
+- Function Name
+- Function URL
+- Full deployment summary
+
+## Testing the Workflow
+
+### Test Plan (Manual Run)
+
+1. Go to Actions tab in GitHub
+2. Select "Terraform Deploy" workflow
+3. Click "Run workflow"
+4. Select "plan" action
+5. Verify the plan completes successfully
+
+### Test Apply (Push to Main)
+
+1. Make a small change to terraform files
+2. Create a PR
+3. Verify plan runs and comments on PR
+4. Merge PR to main
+5. Verify apply runs automatically
+
+## Troubleshooting
+
+### Authentication Errors
+
+```
+Error: google: could not find default credentials
+```
+
+**Solution**: Ensure `GCP_CREDENTIALS` secret is set correctly with valid JSON
+
+### Permission Denied Errors
+
+```
+Error: Error creating function: googleapi: Error 403: Permission denied
+```
+
+**Solution**: Verify the service account has all required roles (see setup above)
+
+### Missing Secrets
+
+```
+Error: Required variable not set: gcp_project
+```
+
+**Solution**: Ensure all required secrets are configured in GitHub
+
+### State Lock Errors
+
+If using GCS backend and getting lock errors:
+
+```bash
+# Manually unlock (use with caution)
+terraform force-unlock <lock-id>
+```
+
+## Backend Configuration
+
+If using a remote backend (GCS or Terraform Cloud), update the workflow to include:
+
+```yaml
+- name: Terraform Init
+  run: |
+    terraform init \
+      -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
+      -backend-config="prefix=v2v2b-interrogator/state"
+```
+
+And add the secret:
+- **Secret name**: `TF_STATE_BUCKET`
+- **Secret value**: Your GCS bucket name
+
+## Cost Optimization
+
+To avoid unnecessary runs:
+
+1. The workflow only triggers on changes to `terraform/**` files
+2. PRs only run `plan` (no cost)
+3. Only pushes to `main` run `apply`
+4. Manual triggers require explicit confirmation
+
+## Security Best Practices
+
+1. ✅ Use Workload Identity Federation instead of service account keys
+2. ✅ Never commit credentials to the repository
+3. ✅ Use separate service accounts for different environments
+4. ✅ Enable branch protection on `main` to require PR reviews
+5. ✅ Regularly rotate service account keys (if using them)
+6. ✅ Review security scan results before merging PRs
+7. ✅ Use least-privilege IAM roles
+
+## Additional Configuration
+
+### Environment-Specific Deployments
+
+To deploy to multiple environments (dev, staging, prod):
+
+1. Create separate workflows or use environments:
+```yaml
+environment:
+  name: production
+  url: ${{ steps.outputs.outputs.function_url }}
+```
+
+2. Use environment-specific secrets in GitHub
+
+### Notifications
+
+Add Slack or email notifications on failure:
+
+```yaml
+- name: Notify on failure
+  if: failure()
+  uses: slackapi/slack-github-action@v1
+  with:
+    webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+```
+
+## Support
+
+For issues with:
+- **GitHub Actions**: Check the Actions tab for detailed logs
+- **Terraform**: Review terraform plan output in PR comments
+- **GCP**: Check Google Cloud Console for resource status

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,214 @@
+name: 'Terraform Deploy'
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform.yml'
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Terraform action to perform'
+        required: true
+        default: 'plan'
+        type: choice
+        options:
+          - plan
+          - apply
+          - destroy
+
+env:
+  TERRAFORM_VERSION: '1.6.0'
+  WORKING_DIR: './terraform'
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  terraform:
+    name: 'Terraform ${{ github.event_name == ''pull_request'' && ''Plan'' || github.event.inputs.action || ''Apply'' }}'
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ${{ env.WORKING_DIR }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+
+      # Option 1: Using Workload Identity Federation (Recommended for production)
+      # Uncomment this section and comment out the service account key section below
+      # - name: Authenticate to Google Cloud (Workload Identity)
+      #   uses: google-github-actions/auth@v2
+      #   with:
+      #     workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      #     service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      # Option 2: Using Service Account Key
+      # This is simpler but less secure than Workload Identity
+      - name: Authenticate to Google Cloud (Service Account Key)
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Terraform Format Check
+        id: fmt
+        run: terraform fmt -check -recursive
+        continue-on-error: true
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          terraform plan -no-color -input=false -out=tfplan \
+            -var="gcp_project=${{ secrets.GCP_PROJECT_ID }}" \
+            -var="github_token=${{ secrets.GH_TOKEN }}" \
+            -var="repo_name=${{ secrets.REPO_NAME }}"
+        continue-on-error: true
+        env:
+          TF_VAR_gcp_project: ${{ secrets.GCP_PROJECT_ID }}
+          TF_VAR_github_token: ${{ secrets.GH_TOKEN }}
+          TF_VAR_repo_name: ${{ secrets.REPO_NAME }}
+
+      - name: Comment PR with Plan
+        uses: actions/github-script@v7
+        if: github.event_name == 'pull_request'
+        env:
+          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+            <details><summary>Validation Output</summary>
+
+            \`\`\`\n
+            ${{ steps.validate.outputs.stdout }}
+            \`\`\`
+
+            </details>
+
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+
+            <details><summary>Show Plan</summary>
+
+            \`\`\`\n
+            ${process.env.PLAN}
+            \`\`\`
+
+            </details>
+
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.WORKING_DIR }}\`, Workflow: \`${{ github.workflow }}\`*`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+      - name: Terraform Apply
+        if: |
+          github.ref == 'refs/heads/main' &&
+          github.event_name == 'push' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
+        run: terraform apply -auto-approve tfplan
+
+      - name: Terraform Destroy
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+        run: |
+          terraform destroy -auto-approve \
+            -var="gcp_project=${{ secrets.GCP_PROJECT_ID }}" \
+            -var="github_token=${{ secrets.GH_TOKEN }}" \
+            -var="repo_name=${{ secrets.REPO_NAME }}"
+        env:
+          TF_VAR_gcp_project: ${{ secrets.GCP_PROJECT_ID }}
+          TF_VAR_github_token: ${{ secrets.GH_TOKEN }}
+          TF_VAR_repo_name: ${{ secrets.REPO_NAME }}
+
+      - name: Get Terraform Outputs
+        if: |
+          (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
+        id: outputs
+        run: |
+          echo "function_url=$(terraform output -raw function_url 2>/dev/null || echo 'N/A')" >> $GITHUB_OUTPUT
+          echo "function_name=$(terraform output -raw function_name 2>/dev/null || echo 'N/A')" >> $GITHUB_OUTPUT
+
+      - name: Display Deployment Summary
+        if: |
+          (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
+        run: |
+          echo "================================================================"
+          echo "Deployment Summary"
+          echo "================================================================"
+          echo "Function Name: ${{ steps.outputs.outputs.function_name }}"
+          echo "Function URL: ${{ steps.outputs.outputs.function_url }}"
+          echo "================================================================"
+
+      - name: Upload Terraform Plan
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-plan
+          path: ${{ env.WORKING_DIR }}/tfplan
+          retention-days: 5
+
+  security:
+    name: 'Security Scan'
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    defaults:
+      run:
+        working-directory: ./terraform
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run tfsec
+        uses: aquasecurity/tfsec-action@v1.0.3
+        with:
+          working_directory: terraform
+          soft_fail: true
+
+      - name: Run Checkov
+        uses: bridgecrewio/checkov-action@v12
+        with:
+          directory: terraform
+          framework: terraform
+          soft_fail: true
+          output_format: cli


### PR DESCRIPTION
Add comprehensive GitHub Actions pipeline for automating Terraform deployments:

- Automated terraform plan on pull requests with PR comments
- Automated terraform apply on push to main branch
- Manual workflow dispatch with plan/apply/destroy options
- GCP authentication support (both service account key and Workload Identity)
- Security scanning with tfsec and Checkov
- Terraform validation and formatting checks
- Deployment summary outputs

Includes detailed setup documentation for configuring required GitHub secrets and GCP authentication methods.