### PR TITLE
Fix GitHub Actions auth workflow error

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -52,20 +52,19 @@ jobs:
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
-      # Option 1: Using Workload Identity Federation (Recommended for production)
-      # Uncomment this section and comment out the service account key section below
-      # - name: Authenticate to Google Cloud (Workload Identity)
-      #   uses: google-github-actions/auth@v2
-      #   with:
-      #     workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      #     service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-
-      # Option 2: Using Service Account Key
-      # This is simpler but less secure than Workload Identity
-      - name: Authenticate to Google Cloud (Service Account Key)
+      # Using Workload Identity Federation (Recommended for production)
+      - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      # Alternative: Using Service Account Key (less secure, commented out)
+      # Uncomment this section and comment out the Workload Identity section above if needed
+      # - name: Authenticate to Google Cloud (Service Account Key)
+      #   uses: google-github-actions/auth@v2
+      #   with:
+      #     credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
…P auth

- Switch from credentials_json to workload_identity_provider
- Fixes authentication error requiring exactly one auth method
- Uses secure WIF instead of service account keys
- Requires GCP_WORKLOAD_IDENTITY_PROVIDER and GCP_SERVICE_ACCOUNT secrets

Resolves GitHub Actions auth error in terraform.yml workflow